### PR TITLE
fix: AttributeError when non-authenticated user updates cart

### DIFF
--- a/ambikaapp/views.py
+++ b/ambikaapp/views.py
@@ -364,14 +364,14 @@ def update_quantity(request):
         data = json.loads(request.body.decode('utf-8'))
         item_id = data.get('id')
         new_quantity = data.get('quantity')
-        customer = request.user.customer        
+
         # Check if the user is authenticated
-        if customer=="AnonymousUser":
-            print("anonymous")
         if request.user.is_authenticated:
             try:
                 # Retrieve the OrderItem instance by its ID
                 order_item = OrderItem.objects.get(pk=item_id)
+
+                customer = request.user.customer
 
                 order_item.quantity = new_quantity
                 order_item.customer = customer


### PR DESCRIPTION
This PR fixes an issue where an 'AttributeError' was occurring when non-authenticated users attempted to update cart items or addons, as they do not have a 'customer' instance. To resolve this, the code `customer = request.user.customer` has been appropriately placed within the 'if' block to ensure it is only executed for authenticated users.